### PR TITLE
Fix ruby 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 squiggles.txt
 Gemfile.lock
 README.md.html
+
+.ruby-version

--- a/lib/termplot/consumers/base_consumer.rb
+++ b/lib/termplot/consumers/base_consumer.rb
@@ -31,7 +31,7 @@ module Termplot
         Shell.init(clear: options.full_screen)
         renderer_thread.start
 
-        # Blocks main thread
+        # Blocks main thread to produce values from the producer pool
         producer_pool.start_and_block
 
         # At this point producer threads have all exited, tell renderer to

--- a/lib/termplot/consumers/single_source_consumer.rb
+++ b/lib/termplot/consumers/single_source_consumer.rb
@@ -25,7 +25,7 @@ module Termplot
           "hist"       => "Termplot::Widgets::HistogramWidget",
         }
         klass = Object.const_get(wigdet_classes[options.type])
-        @widget = klass.new(options.to_h)
+        @widget = klass.new(**options.to_h)
       end
 
       def build_producer

--- a/lib/termplot/message_broker.rb
+++ b/lib/termplot/message_broker.rb
@@ -29,8 +29,7 @@ module Termplot
 
     def closed?
       mutex.synchronize do
-        brokers.count > 0 &&
-          brokers.all?(:closed?)
+        (brokers.count == 0) || brokers.all?(&:closed?)
       end
     end
 
@@ -90,6 +89,10 @@ module Termplot
 
     def close
       queue.close
+    end
+
+    def closed?
+      queue.closed?
     end
 
     private

--- a/lib/termplot/message_broker.rb
+++ b/lib/termplot/message_broker.rb
@@ -72,7 +72,7 @@ module Termplot
       register_callbacks
     end
 
-    def on_message(block = Proc.new)
+    def on_message(&block)
       on_message_callbacks.push(block)
     end
 

--- a/lib/termplot/version.rb
+++ b/lib/termplot/version.rb
@@ -1,3 +1,3 @@
 module Termplot
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
This PR fixes ruby 3 keyword arguments compatibility when initializing widgets (in `single_source_consumer.rb`).

It also addresses a bug in the message broker implementation (`MessageBrokerPool#closed?`) which didn't correctly check when the brokers in the pool had all closed their queues. This was incorrect behaviour but didn't always fail reliably before ruby 3. in ruby 3 this results in a consistent hard failure, which caused the issue to surface.